### PR TITLE
Full example of an authorised website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,3 +23,4 @@ cabal.project.local~
 .ghc.environment.*
 
 client_session_key.aes
+config.toml

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ Cookie example:
 
 You'll need to make a GitHub OAuth application.
 
-The details of which you'll need to place in `./example-basic/config.toml`.
+The details of which you'll need to place in `./config.toml`. See
+`./config.example.toml` for an example.
 
 The most important detail is that the callback URL on github, and in the
 config, is set to the same thing:

--- a/config.example.toml
+++ b/config.example.toml
@@ -1,21 +1,11 @@
-# Example-Cookies
+[oauth-google]
+  name         = "servant-oauth2-example-basic"
+  callback_url = "http://localhost:8080/auth/google/complete"
+  id           = "..."
+  secret       = "..."
 
-### Setup
-
-Create a file in `./example-basic` called `config.toml`:
-
-```
 [oauth-github]
   name         = "servant-oauth2-example-basic"
   callback_url = "http://localhost:8080/auth/github/complete"
   id           = "..."
   secret       = "..."
-```
-
-### Running
-
-From the home directory:
-
-```
-stack run -- example-cookies
-```

--- a/example-authorised/Config.hs
+++ b/example-authorised/Config.hs
@@ -1,0 +1,1 @@
+../example-basic/Config.hs

--- a/example-authorised/README.md
+++ b/example-authorised/README.md
@@ -1,0 +1,25 @@
+# Example-Authorised
+
+Building on the _cookies_ example, we will build in type-level security into
+the servant API, so that we can have an 'admin' area which only certain users
+can access; i.e. we'll perform "authorisation" of users as well.
+
+### Setup
+
+Create a file `example-basic` called `config.toml`:
+
+```
+[oauth-github]
+  name         = "servant-oauth2-example-basic"
+  callback_url = "http://localhost:8080/auth/github/complete"
+  id           = "..."
+  secret       = "..."
+```
+
+### Running
+
+From the home directory:
+
+```
+stack run -- example-auth
+```

--- a/example-authorised/db.txt
+++ b/example-authorised/db.txt
@@ -1,0 +1,2 @@
+silky@users.noreply.github.com,admin
+noon.vandersilk@tweag.io,user

--- a/example-basic/.gitignore
+++ b/example-basic/.gitignore
@@ -1,1 +1,0 @@
-config.toml

--- a/example-basic/Main.hs
+++ b/example-basic/Main.hs
@@ -122,7 +122,7 @@ server githubCallbackUrl githubSettings googleCallbackUrl googleSettings =
 
 main :: IO ()
 main = do
-  eitherConfig <- decodeFileExact configCodec ("./example-basic/config.toml")
+  eitherConfig <- decodeFileExact configCodec ("./config.toml")
   config <-
     either
       (\errors -> fail $ "unable to parse configuration: " <> show errors)

--- a/example-cookies/.gitignore
+++ b/example-cookies/.gitignore
@@ -1,1 +1,0 @@
-config.toml

--- a/example-cookies/Main.hs
+++ b/example-cookies/Main.hs
@@ -111,7 +111,7 @@ server OAuthConfig {_callbackUrl} settings =
 
 main :: IO ()
 main = do
-  eitherConfig <- decodeFileExact configCodec ("./example-cookies/config.toml")
+  eitherConfig <- decodeFileExact configCodec ("./config.toml")
   config <-
     either
       (\errors -> fail $ "unable to parse configuration: " <> show errors)

--- a/fourmolu.yaml
+++ b/fourmolu.yaml
@@ -1,6 +1,6 @@
 indentation: 2
 comma-style: leading
-import-export-style: diff-friendly
+import-export-style: leading
 indent-wheres: false
 record-brace-space: true
 respectful: true

--- a/package.yaml
+++ b/package.yaml
@@ -37,12 +37,14 @@ dependencies:
   - cookie
   - hoauth2
   - http-types
+  - mtl
   - servant
   - servant-blaze
   - servant-server
   - shakespeare
   - text
   - tomland
+  - unordered-containers
   - uri-bytestring
   - wai
   - wai-middleware-auth
@@ -57,6 +59,12 @@ executables:
 
   example-cookies:
     source-dirs:      example-cookies
+    main:             Main.hs
+    dependencies:
+      - servant-oauth2
+
+  example-auth:
+    source-dirs:      example-authorised
     main:             Main.hs
     dependencies:
       - servant-oauth2

--- a/servant-oauth2.cabal
+++ b/servant-oauth2.cabal
@@ -47,12 +47,58 @@ library
     , cookie
     , hoauth2
     , http-types
+    , mtl
     , servant
     , servant-blaze
     , servant-server
     , shakespeare
     , text
     , tomland
+    , unordered-containers
+    , uri-bytestring
+    , wai
+    , wai-middleware-auth
+    , warp
+  default-language: Haskell2010
+
+executable example-auth
+  main-is: Main.hs
+  other-modules:
+      Config
+      Paths_servant_oauth2
+  hs-source-dirs:
+      example-authorised
+  default-extensions:
+      DataKinds
+      DeriveGeneric
+      DerivingStrategies
+      FlexibleContexts
+      ImportQualifiedPost
+      KindSignatures
+      OverloadedStrings
+      PackageImports
+      ScopedTypeVariables
+      TypeApplications
+      TypeOperators
+  ghc-options: -W -Wall
+  build-depends:
+      base >=4.7 && <5
+    , base64-bytestring
+    , binary
+    , bytestring
+    , clientsession
+    , cookie
+    , hoauth2
+    , http-types
+    , mtl
+    , servant
+    , servant-blaze
+    , servant-oauth2
+    , servant-server
+    , shakespeare
+    , text
+    , tomland
+    , unordered-containers
     , uri-bytestring
     , wai
     , wai-middleware-auth
@@ -88,6 +134,7 @@ executable example-basic
     , cookie
     , hoauth2
     , http-types
+    , mtl
     , servant
     , servant-blaze
     , servant-oauth2
@@ -95,6 +142,7 @@ executable example-basic
     , shakespeare
     , text
     , tomland
+    , unordered-containers
     , uri-bytestring
     , wai
     , wai-middleware-auth
@@ -130,6 +178,7 @@ executable example-cookies
     , cookie
     , hoauth2
     , http-types
+    , mtl
     , servant
     , servant-blaze
     , servant-oauth2
@@ -137,6 +186,7 @@ executable example-cookies
     , shakespeare
     , text
     , tomland
+    , unordered-containers
     , uri-bytestring
     , wai
     , wai-middleware-auth

--- a/src/Servant/OAuth2.hs
+++ b/src/Servant/OAuth2.hs
@@ -60,9 +60,10 @@ data OAuth2Routes (rs :: [Type]) mode = AuthRoutes
 
 
 authServer ::
-  forall a (rs :: [Type]).
+  forall m a (rs :: [Type]).
+  Monad m =>
   Tag a (Union rs) ->
-  OAuth2Routes rs (AsServerT Handler)
+  OAuth2Routes rs (AsServerT m)
 authServer h =
   AuthRoutes
     { complete = pure (unTag h)

--- a/src/Servant/OAuth2/Cookies.hs
+++ b/src/Servant/OAuth2/Cookies.hs
@@ -39,10 +39,7 @@ import "cookie" Web.Cookie (
 type RedirectWithCookie = Headers '[Header "Location" Text, Header "Set-Cookie" SetCookie] NoContent
 
 
-redirectWithCookie ::
-  Text ->
-  SetCookie ->
-  RedirectWithCookie
+redirectWithCookie :: Text -> SetCookie -> RedirectWithCookie
 redirectWithCookie destination cookie =
   addHeader destination (addHeader cookie NoContent)
 


### PR DESCRIPTION
This adds an example of performing "authorisation"; i.e. verifying that
a certain user belongs to a role, and then permitting access on that
basis.

In particular, we do this at the type level! We're only able to do this
because of how the authentication mechanism has been structured.

In order to use this example, you will want to change the data in `db.txt` 😀 